### PR TITLE
Add cursor actions and fix cursor contexts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ Changes between each version before then will not be listed.
 
 ## 2.2.0 <!-- Assuming we'll just put everything into the next minor release, change to 2.1.3 if we decide to release a patch first -->
 
+### Added settings
+
+- New permission for getting the user's cursor / selection: `neuropilot.permission.getUserSelection`
+
 ### Added features
 
 - A tooltip will now show when hovering over Neuro-highlighted text, indicating that Neuro highlighted it, and how (either through finding text or manually).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,9 @@ Changes between each version before then will not be listed.
   - This automatically cancels Neuro's action requests if certain events happen.
   - Example: If Neuro wants to insert text, that request will auto-cancel if the active file is switched.
   - You can disable this with the new `Enable Cancel Events` setting (defaulted to on).
+- Neuro can now get and replace the user's current selection.
+  - This only works in Neuro-safe files.
+  - This requires the new permission *Get User Selection*, replacing the selection additionally requires *Edit Active Document*.
 
 ### Changes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,11 +19,14 @@ Changes between each version before then will not be listed.
   - The specific colour used now is RGBA 202 22 175 1 as opposed to RGBA 255 255 0 1.
 - Some Copilot mode prompts for editing actions have been rewritten majorly to properly reflect the options available to Neuro.
 - Clarified whose cursor will be moved in action descriptions and contexts.
+- Context returned from editing actions now uses a common format.
 
 ### Fixes
 
 - Fixed automatically opening files created by Neuro when she only has Copilot permission for opening files.
 - `rename_git_remote` now has a Git extension validator attached to it, matching all other Git actions.
+- Usage of CRLF and LF in context was inconsistent across actions, and sometimes even inconsistent within the same context. This has now (hopefully) been fixed to only use LF.
+- Line numbers should now appear for all actions.
 
 ## 2.1.2
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,7 +36,7 @@ Changes between each version before then will not be listed.
   - You can disable this with the new `Enable Cancel Events` setting (defaulted to on).
 - Neuro can now get and replace the user's current selection.
   - This only works in Neuro-safe files.
-  - This requires the new permission *Get User Selection*, replacing the selection additionally requires *Edit Active Document*.
+  - This requires the new permissions *Get User Selection* and *Edit Active Document*.
 
 ### Changes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ Changes between each version before then will not be listed.
   - AHHHH MY EYES - Vedal
   - The specific colour used now is RGBA 202 22 175 1 as opposed to RGBA 255 255 0 1.
 - Some Copilot mode prompts for editing actions have been rewritten majorly to properly reflect the options available to Neuro.
+- Clarified whose cursor will be moved in action descriptions and contexts.
 
 ### Fixes
 

--- a/package.json
+++ b/package.json
@@ -694,6 +694,21 @@
 						],
 						"markdownDescription": "Allow Neuro to get access to linting problems within loaded files."
 					},
+					"neuropilot.permission.getUserSelection": {
+						"type": "string",
+						"default": "Off",
+						"enum": [
+							"Off",
+							"Copilot",
+							"Autopilot"
+						],
+						"enumDescriptions": [
+							"Disable this permission.",
+							"Require approval before execution.",
+							"Execute without oversight."
+						],
+						"markdownDescription": "Allow Neuro to see your cursor position and selection within Neuro-safe files."
+					},
 					"neuropilot.access.dotFiles": {
 						"type": "boolean",
 						"default": false,

--- a/package.json
+++ b/package.json
@@ -410,6 +410,7 @@
 								"get_files",
 								"get_folder_lint_problems",
 								"get_git_config",
+								"get_user_selection",
 								"get_workspace_lint_problems",
 								"git_blame",
 								"git_log",

--- a/package.json
+++ b/package.json
@@ -441,6 +441,7 @@
 								"rename_file_or_folder",
 								"rename_git_remote",
 								"replace_text",
+								"replace_user_selection",
 								"request_cookie",
 								"rewrite_all",
 								"rewrite_lines",

--- a/playground/.vscode/settings.json
+++ b/playground/.vscode/settings.json
@@ -13,6 +13,7 @@
     "neuropilot.showTimeOnTerminalStart": true,
     "neuropilot.permission.terminalAccess": "Copilot",
     "neuropilot.permission.accessLintingAnalysis": "Copilot",
+    "neuropilot.permission.getUserSelection": "Copilot",
     "neuropilot.terminals": [
         {
             "name": "PowerShell",

--- a/playground/README.md
+++ b/playground/README.md
@@ -1,0 +1,7 @@
+# NeuroPilot Playground
+
+This folder is meant for testing NeuroPilot actions.
+The different files in here are pretty much all just for testing the various permissions.
+
+For safety reasons, all permissions are set to `Copilot` here.
+You can change them to `Autopilot` for testing, but please don't commit these values.

--- a/src/config.ts
+++ b/src/config.ts
@@ -76,7 +76,7 @@ export interface Permission {
 /** Collection of strings for use in {@link actionResultNoPermission}. */
 class Permissions {
     get openFiles() { return { id: 'openFiles', infinitive: 'open files' }; }
-    get editActiveDocument() { return { id: 'editActiveDocument', infinitive: 'edit documents' }; }
+    get editActiveDocument() { return { id: 'editActiveDocument', infinitive: 'edit or view documents' }; }
     get create() { return { id: 'create', infinitive: 'create files or folders' }; }
     get rename() { return { id: 'rename', infinitive: 'rename files or folders' }; }
     get delete() { return { id: 'delete', infinitive: 'delete files or folders' }; }

--- a/src/config.ts
+++ b/src/config.ts
@@ -89,6 +89,7 @@ class Permissions {
     get gitConfigs() { return { id: 'gitConfigs', infinitive: 'edit the Git configuration' }; }
     get terminalAccess() { return { id: 'terminalAccess', infinitive: 'access the terminal' }; }
     get accessLintingAnalysis() { return { id: 'accessLintingAnalysis', infinitive: 'view linting problems' }; }
+    get getUserSelection() { return { id: 'getUserSelection', infinitive: 'get Vedal\'s cursor' }; }
 }
 
 export const PERMISSIONS = new Permissions();

--- a/src/config.ts
+++ b/src/config.ts
@@ -2,6 +2,12 @@ import * as vscode from 'vscode';
 import { Action } from 'neuro-game-sdk';
 import { NEURO } from './constants';
 
+//#region Types
+
+export type CursorPositionContextStyle = 'off' | 'inline' | 'lineAndColumn' | 'both';
+
+//#endregion
+
 /** Permission level enums */
 export const enum PermissionLevel {
     OFF = 0,
@@ -109,7 +115,7 @@ class Config {
     get defaultOpenDocsWindow(): string { return get('defaultOpenDocsWindow')!; }
     get disabledActions(): string[] { return get('disabledActions')!; }
     get sendContentsOnFileChange(): boolean { return get('sendContentsOnFileChange')!; }
-    get cursorPositionContextStyle(): string { return get('cursorPositionContextStyle')!; }
+    get cursorPositionContextStyle(): CursorPositionContextStyle { return get('cursorPositionContextStyle')!; }
     get lineNumberContextFormat(): string { return get('lineNumberContextFormat')!; }
 
     get terminals(): { name: string; path: string; args?: string[]; }[] { return get('terminals')!; }

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -76,6 +76,8 @@ interface Neuro {
     currentController: string | null;
     /** If this is `true`, all permissions return `Off`. */
     killSwitch: boolean;
+    /** The last known user selection, or null if there is none or it is in a non-Neuro-safe file. */
+    lastKnownUserSelection: vscode.Selection | null;
 }
 
 
@@ -108,6 +110,7 @@ export const NEURO: Neuro = {
     highlightDecorationType: null,
     currentController: null,
     killSwitch: false,
+    lastKnownUserSelection: null,
 };
 
 // this will likely be transformed for a different use later when the API rolls around

--- a/src/editing.ts
+++ b/src/editing.ts
@@ -168,20 +168,20 @@ function createLineRangeValidator(path = '') {
 export const editingActions = {
     place_cursor: {
         name: 'place_cursor',
-        description: 'Place the cursor in the current file at the specified position. Line and column numbers are one-based for "absolute" and zero-based for "relative".',
+        description: 'Place your cursor in the current file at the specified position. Line and column numbers are one-based for "absolute" and zero-based for "relative".',
         schema: POSITION_SCHEMA,
         permissions: [PERMISSIONS.editActiveDocument],
         handler: handlePlaceCursor,
         validator: [checkCurrentFile, createPositionValidator()],
-        promptGenerator: (actionData: ActionData) => `${actionData.params.type === 'absolute' ? 'place the cursor at' : 'move the cursor by'} (${actionData.params.line}:${actionData.params.column}).`,
+        promptGenerator: (actionData: ActionData) => `${actionData.params.type === 'absolute' ? 'place her cursor at' : 'move her cursor by'} (${actionData.params.line}:${actionData.params.column}).`,
     },
     get_cursor: {
         name: 'get_cursor',
-        description: 'Get the current cursor position and the text surrounding it.',
+        description: 'Get your current cursor position and the text surrounding it.',
         permissions: [PERMISSIONS.editActiveDocument],
         handler: handleGetCursor,
         validator: [checkCurrentFile],
-        promptGenerator: 'get the current cursor position and the text surrounding it.',
+        promptGenerator: 'get her current cursor position and the text surrounding it.',
     },
     get_content: {
         name: 'get_content',
@@ -600,7 +600,7 @@ export function handleGetCursor(_actionData: ActionData): string | undefined {
     const relativePath = vscode.workspace.asRelativePath(document.uri);
     logOutput('INFO', `Sending cursor position to ${NEURO.currentController}`);
 
-    return `In file ${relativePath}\n\nCursor is at (${cursorPosition.line + 1}:${cursorPosition.character + 1})\n\n${formatContext(cursorContext)}`;
+    return `In file ${relativePath}\n\nYour cursor is at (${cursorPosition.line + 1}:${cursorPosition.character + 1})\n\n${formatContext(cursorContext)}`;
 }
 
 export function handleGetContent(): string {
@@ -675,7 +675,7 @@ export function handleInsertText(actionData: ActionData): string | undefined {
                 type: DiffRangeType.Added,
             });
             const cursorContext = getPositionContext(document, insertStart, insertEnd);
-            NEURO.client?.sendContext(`Inserted text into document and moved cursor\n\n${formatContext(cursorContext)}`);
+            NEURO.client?.sendContext(`Inserted text into document and moved your cursor\n\n${formatContext(cursorContext)}`);
         }
         else {
             NEURO.client?.sendContext(contextFailure('Failed to insert text'));
@@ -885,7 +885,7 @@ export function handleFindText(actionData: ActionData): string | undefined {
         }
         const cursorContext = getPositionContext(document, startPosition);
         logOutput('INFO', `Placed cursor at (${startPosition.line + 1}:${startPosition.character + 1})`);
-        return `Found match and placed cursor at (${startPosition.line + 1}:${startPosition.character + 1})\n\n${formatContext(cursorContext)}`;
+        return `Found match and placed your cursor at (${startPosition.line + 1}:${startPosition.character + 1})\n\n${formatContext(cursorContext)}`;
     }
     else {
         // Multiple matches
@@ -920,7 +920,7 @@ export function handleUndo(_actionData: ActionData): string | undefined {
     vscode.commands.executeCommand('undo').then(
         () => {
             logOutput('INFO', 'Undoing last action in document');
-            // We don't keep track of the cursor position in the undo stack, so we reset it to the real cursor position
+            // We don't keep track of the virtual cursor position in the undo stack, so we reset it to the real cursor position
             const cursorContext = getPositionContext(document, vscode.window.activeTextEditor!.selection.active);
             setVirtualCursor(vscode.window.activeTextEditor!.selection.active);
             NEURO.client?.sendContext(`Undid last action in document\n\n${formatContext(cursorContext)}`);

--- a/src/file_actions.ts
+++ b/src/file_actions.ts
@@ -1,7 +1,7 @@
 import * as vscode from 'vscode';
 
 import { NEURO } from '@/constants';
-import { filterFileContents, getFence, getVirtualCursor, getWorkspacePath, getWorkspaceUri, isBinary, isPathNeuroSafe, logOutput, normalizePath } from '@/utils';
+import { formatContext, getFence, getPositionContext, getVirtualCursor, getWorkspacePath, getWorkspaceUri, isBinary, isPathNeuroSafe, logOutput, normalizePath } from '@/utils';
 import { ActionData, contextNoAccess, RCEAction, actionValidationFailure, actionValidationAccept, ActionValidationResult, stripToActions } from '@/neuro_client_helper';
 import { CONFIG, PERMISSIONS, PermissionLevel, getPermissionLevel, isActionEnabled } from '@/config';
 
@@ -475,11 +475,9 @@ export function handleOpenFile(actionData: ActionData): string | undefined {
 
             // Usually handled by editorChangedHandler in editing.ts, except if this setting is off
             if (!CONFIG.sendContentsOnFileChange) {
-                const cursorOffset = document.offsetAt(getVirtualCursor() ?? new vscode.Position(0, 0));
-                let text = document.getText();
-                text = text.slice(0, cursorOffset) + '<<<|>>>' + text.slice(cursorOffset);
-                const fence = getFence(text);
-                NEURO.client?.sendContext(`Opened file ${relativePath}\n\nContent (cursor position denoted by \`<<<|>>>\`):\n\n${fence}${document.languageId}\n${filterFileContents(text)}\n${fence}`);
+                const cursor = getVirtualCursor()!;
+                const cursorContext = getPositionContext(document, cursor);
+                NEURO.client?.sendContext(formatContext(cursorContext));
             }
         }
         catch (erm: unknown) {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -226,7 +226,7 @@ export function getPositionContext(document: vscode.TextDocument, options: Neuro
     const endLine = Math.min(document.lineCount - 1, options.position2.line + afterContextLength);
 
     // If the cursor is defined and inside the range, split the context into before and after the cursor
-    if (options.cursorPosition && options.cursorPosition.line >= options.position.line && options.cursorPosition.line <= options.position2.line) {
+    if (options.cursorPosition && options.cursorPosition.line >= startLine && options.cursorPosition.line <= endLine) {
         const contextBefore = document.getText(new vscode.Range(new vscode.Position(startLine, 0), options.cursorPosition));
         const contextAfter = document.getText(new vscode.Range(options.cursorPosition, new vscode.Position(endLine, document.lineAt(endLine).text.length)));
         return {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -641,16 +641,20 @@ export function formatContext(context: NeuroPositionContext, overrideCursorStyle
     }
     const contextAfter = contextArray.join('\n');
 
-    const cursorStyle = overrideCursorStyle ?? CONFIG.cursorPositionContextStyle;
+    let effectiveCursorStyle = overrideCursorStyle ?? CONFIG.cursorPositionContextStyle;
+    if (!context.cursorDefined && effectiveCursorStyle === 'both')
+        effectiveCursorStyle = 'lineAndColumn';
+    if (!context.cursorDefined && effectiveCursorStyle === 'inline')
+        effectiveCursorStyle = 'off';
 
     const cursor = getVirtualCursor()!;
-    const cursorText = ['inline', 'both'].includes(cursorStyle) && context.cursorDefined
+    const cursorText = ['inline', 'both'].includes(effectiveCursorStyle) && context.cursorDefined
         ? '<<<|>>>'
         : '';
     const cursorNote =
-        cursorStyle === 'inline' ? 'Your cursor\'s position is denoted by `<<<|>>>`. '
-        : cursorStyle === 'lineAndColumn' ? `Your cursor is at ${cursor.line + 1}:${cursor.character + 1}. `
-        : cursorStyle === 'both' ? `Your cursor is at ${cursor.line + 1}:${cursor.character + 1}, denoted by \`<<<|>>>\`. `
+        effectiveCursorStyle === 'inline' ? 'Your cursor\'s position is denoted by `<<<|>>>`. '
+        : effectiveCursorStyle === 'lineAndColumn' ? `Your cursor is at ${cursor.line + 1}:${cursor.character + 1}. `
+        : effectiveCursorStyle === 'both' ? `Your cursor is at ${cursor.line + 1}:${cursor.character + 1}, denoted by \`<<<|>>>\`. `
         : '';
 
     return `File context for lines ${context.startLine + 1}-${context.endLine + 1} of ${context.totalLines}. ${cursorNote}${lineNumberNote}Content:\n\n${fence}\n${contextBefore}${cursorText}${contextAfter}\n${fence}`;


### PR DESCRIPTION
Resolves #116.

Also makes all file content contexts use the common format. For this, I moved `formatContext` from `editing.ts` to `utils.ts`, since it's now needed by `file_actions.ts` as well.